### PR TITLE
feat: add typstyle formatter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,30 @@ jobs:
             .
             .github/**
 
+  format-typst:
+    name: Format Typst
+    needs: determine-changes
+    if: ${{ needs.determine-changes.outputs.typst == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the main repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Run typstyle
+        uses: typstyle-rs/typstyle-action@v0.9.3
+
+      - name: Check formatting
+        run: |
+          # Show unified diff to help reviewers
+          git --no-pager diff
+          # Fail when there are changes
+          if ! git diff --quiet; then
+            echo "::error title=typstyle::Formatting required. Please run typstyle locally or push a commit with formatted files."
+            exit 1
+          fi
+        shell: bash
+
   compile-typst:
     name: Compile Typst
     needs: determine-changes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,19 @@
 repos:
+  - repo: local
+    hooks:
+      - id: typstyle-format
+        name: typstyle format
+        entry: typstyle -i
+        language: system
+        files: \.typ$
+        args: []
+      - id: typstyle-check
+        name: typstyle check
+        entry: typstyle --check
+        language: system
+        files: \.typ$
+        stages: [pre-push]
+
   - repo: https://github.com/crate-ci/typos
     rev: v1.33.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # typst-repository-template
 
+[![Typst Version](https://img.shields.io/badge/typst-0.12%20%7C%200.13-blue)](https://typst.app/)
+[![styled with typstyle](https://img.shields.io/badge/styled_with-typstyle-024a51.svg?style=flat)](https://github.com/typstyle-rs/typstyle)
+
 This is a template repository for Typst projects.
 
 ## GitHub Actions Permissions Setup

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ To enable pre-commit hooks in your repository, you need to install `pre-commit` 
 uvx pre-commit install
 ```
 
+The pre-commit hooks also rely on `typstyle` being installed locally. We recommend installing it with `cargo binstall`:
+
+```console
+cargo binstall typstyle
+```
+
+For other installation methods, please refer to the [official documentation](https://typstyle-rs.github.io/typstyle/installation.html).
+
 ## Version Bumping by Labels
 
 This repository is configured to automatically bump the version when a pull request is merged with one of the following labels:


### PR DESCRIPTION
This PR introduces `typstyle`, an opinionated code formatter for Typst, into the project's workflow.

### Changes

- **CI Integration**:
  - A new `format-typst` job has been added to the `ci.yaml` workflow.
  - This job runs `typstyle` on every push and pull request to ensure that all `.typ` files are correctly formatted.

- **Pre-commit Hooks**:
  - Added `typstyle` hooks to the `.pre-commit-config.yaml`.
  - `typstyle -i` will automatically format `.typ` files on commit.
  - `typstyle --check` will run before pushing to prevent improperly formatted code from being pushed.

- **Documentation**:
  - Updated `README.md` to include installation instructions for `typstyle`, as it's a dependency for the pre-commit hooks.
  - Added `typstyle` and `Typst` version badges to the `README.md`.

This set of changes helps maintain a consistent code style across the project automatically.