### PR TITLE
chore: migrate toml linting to tombi

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -79,10 +79,10 @@
         '/^\\.github/workflows/ci\\.ya?ml$/',
       ],
       matchStrings: [
-        "TAPLO_VERSION: '(?<currentValue>[^']+)'",
+        "uses: tombi-toml/setup-tombi@[a-f0-9]{40}[^\\n]*\\n(?:\\s+with:\\n(?:\\s+[^\\n]+\\n)*?)\\s+version: '(?<currentValue>[^'\\s]+)'",
       ],
       datasourceTemplate: 'github-releases',
-      depNameTemplate: 'tamasfe/taplo',
+      depNameTemplate: 'tombi-toml/tombi',
     },
     {
       customType: 'regex',

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
               - '**/*.json5'
             toml:
               - '**/*.toml'
-              - .taplo.toml
+              - .tombi.toml
             yaml:
               - '**/*.yml'
               - '**/*.yaml'
@@ -229,21 +229,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Taplo
-        env:
-          TAPLO_VERSION: '0.10.0'
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          curl -fsSL "https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}/taplo-linux-x86_64.gz" \
-            | gzip -d > "$HOME/.local/bin/taplo"
-          chmod +x "$HOME/.local/bin/taplo"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Install Tombi
+        uses: tombi-toml/setup-tombi@9880d1d3ba5e745d410c697366c513b337704388 # v1.0.11
+        with:
+          version: '0.10.2'
 
       - name: Check TOML format
-        run: taplo fmt --check
+        run: tombi format --check
 
       - name: Lint TOML
-        run: taplo lint
+        run: tombi lint
 
   lint-yaml:
     name: Lint YAML

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,11 +18,11 @@ repos:
     hooks:
       - id: markdownlint-cli2
 
-  - repo: https://github.com/ComPWA/taplo-pre-commit
-    rev: ade0f95ddcf661c697d4670d2cfcbe95d0048a0a  # frozen: v0.9.3
+  - repo: https://github.com/tombi-toml/tombi-pre-commit
+    rev: 15308df15bc5808d8bbc368acac5ab8b64c5a7b5  # frozen: v0.10.2
     hooks:
-      - id: taplo-format
-      - id: taplo-lint
+      - id: tombi-format
+      - id: tombi-lint
 
   - repo: https://github.com/adrienverge/yamllint
     rev: cba56bcde1fdd01c1deb3f945e69764c291a6530  # frozen: v1.38.0

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,6 +1,0 @@
-include = ["**/*.toml"]
-
-[formatting]
-array_auto_collapse = false
-column_width = 120
-indent_string = "    "

--- a/.tombi.toml
+++ b/.tombi.toml
@@ -1,0 +1,3 @@
+[format]
+[format.rules]
+line-width = 120

--- a/.typos.toml
+++ b/.typos.toml
@@ -3,5 +3,5 @@ typ = "typ"
 
 [files]
 extend-exclude = [
-    "*.bib",
+  "*.bib",
 ]


### PR DESCRIPTION
- Replace Taplo pre-commit hooks with Tombi.
- Move the TOML formatter config from `.taplo.toml` to `.tombi.toml`.
- Apply Tombi formatting where required by the new hook.
- Move away from Taplo because its future maintenance is uncertain: https://github.com/tamasfe/taplo/issues/715
- Use Tombi as a likely successor TOML toolkit: https://github.com/tombi-toml/tombi
