### PR TITLE
chore(ci): pin prek to v0.4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -289,6 +289,7 @@ jobs:
       - name: Check prek
         uses: j178/prek-action@6ad80277337ad479fe43bd70701c3f7f8aa74db3 # v2.0.3
         with:
+          prek-version: 'v0.4.0'
           extra-args: '--all-files --skip no-commit-to-branch'
 
   check-typos:


### PR DESCRIPTION
- Add `prek-version: 'v0.4.0'` input to `j178/prek-action` in `ci.yaml`.
- The existing custom manager in `renovate.json5` already matches this pattern, so future updates will be picked up automatically — no Renovate config change required.