### PR TITLE
ci: remove unused src/test change-detection outputs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,6 @@ jobs:
     name: Determine changed files
     runs-on: ubuntu-latest
     outputs:
-      src: ${{ steps.changed-files.outputs.src_any_changed }}
-      test: ${{ steps.changed-files.outputs.test_any_changed }}
       github_actions: ${{ steps.changed-files.outputs.github_actions_any_changed }}
       github_actions_ci: ${{ steps.changed-files.outputs.github_actions_ci_any_changed }}
       renovate_config: ${{ steps.changed-files.outputs.renovate_config_any_changed }}
@@ -43,12 +41,6 @@ jobs:
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files_yaml: |
-            src:
-              - '**/src/**'
-              - '!**/src/**/*.md'
-            test:
-              - '**/tests/**'
-              - '!**/tests/**/*.md'
             github_actions:
               - .github/workflows/**
             github_actions_ci:


### PR DESCRIPTION
Remove the `src` and `test` outputs from the `determine-changes` job, along with their `files_yaml` group definitions.

These outputs were declared and computed but never referenced by any downstream job, so they were dead configuration.
