### PR TITLE
ci: adjust zizmor advanced security upload

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,12 @@ jobs:
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
         with:
           version: 'v1.24.1'
-          # advanced-security: false  # must be false for private repo
+          advanced-security: >-
+            ${{
+              github.event.repository.private == false &&
+              (github.event_name != 'pull_request' ||
+              github.event.pull_request.head.repo.full_name == github.repository)
+            }}
 
   validate-renovate-config:
     name: Validate Renovate config


### PR DESCRIPTION
- Enable zizmor SARIF upload only when the repository is public.
- Keep upload disabled for private repositories and fork pull_request runs.
