### PR TITLE
ci: cancel superseded pull request workflow runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
     types: [opened, synchronize, reopened]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   TYPST_TARGET_FILES: main.typ # Space-separated list of Typst entrypoint files
 

--- a/.github/workflows/generate-typst-pdf-diff.yaml
+++ b/.github/workflows/generate-typst-pdf-diff.yaml
@@ -26,7 +26,7 @@ on:
         default: main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/generate-typst-pdf-diff.yaml
+++ b/.github/workflows/generate-typst-pdf-diff.yaml
@@ -25,6 +25,10 @@ on:
         required: true
         default: main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   TYPST_TARGET_FILES: main.typ # Space-separated list of Typst entrypoint files
 


### PR DESCRIPTION
- Add workflow-level `concurrency` to `.github/workflows/ci.yaml` and `.github/workflows/generate-typst-pdf-diff.yaml` so a new push to the same PR cancels the superseded run (`cancel-in-progress` only for `pull_request` events).
- Non-PR events (push to `main`, `workflow_dispatch`) use a unique group per run (`github.run_id`), so they always run to completion.
