### PR TITLE
docs(readme): simplify github actions permissions setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,12 @@ This is a template repository for Typst projects.
 
 ## GitHub Actions Permissions Setup
 
-To enable GitHub Actions to run properly in your repository, you need to adjust the default permissions granted
-to the `GITHUB_TOKEN`.
-This is especially important for **private repositories**.
-
-Follow these steps to configure the permissions:
+The version-bump workflow creates pull requests, which requires the following setting to be enabled:
 
 1. Go to the **Settings** tab of your repository.
 2. On the left-hand menu, select **Actions/General**.
-3. Under the **Workflow permissions** section, ensure the following options are selected:
-   - **`Read and write permissions`**: This grants read and write access to the repository for all scopes.
-   - **`Allow GitHub Actions to create and approve pull requests`**: This allows GitHub Actions to create pull requests.
+3. Under the **Workflow permissions** section, enable **`Allow GitHub Actions to create and approve pull requests`**.
 4. Save the changes.
-
-![GitHub Actions permissions setup screenshot](https://github.com/user-attachments/assets/da55e896-e087-486e-aadc-7fc1283dc652)
-
-These settings are **necessary only for private repositories**. For public repositories, this configuration is not required.
 
 ## CI Setup
 


### PR DESCRIPTION
- Keep only the `Allow GitHub Actions to create and approve pull requests` step in the permissions setup section; PR creation with `GITHUB_TOKEN` requires it regardless of repository visibility.
- Drop the `Read and write permissions` instruction (the workflows declare explicit `permissions:` blocks) and the outdated screenshot.
