### PR TITLE
ci: keep typstyle diff so the check still fails the PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -354,6 +354,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tool_name: typstyle
+          cleanup: 'false'
 
       - name: Check formatting
         run: |


### PR DESCRIPTION
`reviewdog/action-suggester` defaults to `cleanup: true`, which stashes and drops the working-tree changes after reporting. The following typstyle format check then runs against an already-clean tree and passes, so formatting violations never fail the PR.

Set `cleanup: false` so the diff is restored and the check keeps failing CI on violations.
