### PR TITLE
ci: fail zizmor job on findings and keep SARIF upload

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,12 +100,21 @@ jobs:
         uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
         with:
           version: 'v1.24.1'
-          advanced-security: >-
-            ${{
-              github.event.repository.private == false &&
-              (github.event_name != 'pull_request' ||
-              github.event.pull_request.head.repo.full_name == github.repository)
-            }}
+          advanced-security: false
+          annotations: true
+
+      - name: Run zizmor (SARIF upload)
+        if: >-
+          ${{
+            always() &&
+            github.event.repository.private == false &&
+            (github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name == github.repository)
+          }}
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          version: 'v1.24.1'
+          advanced-security: true
 
   validate-renovate-config:
     name: Validate Renovate config


### PR DESCRIPTION
Make zizmor findings reliably block CI without depending on a Code Scanning merge-protection ruleset.

- Run zizmor with `advanced-security: false` and `annotations: true` so findings fail the job and surface as inline PR annotations. In SARIF mode (`advanced-security: true`) zizmor suppresses its non-zero exit code, so the job could go green on findings.
- Keep the security tab integration: a separate step uploads SARIF for public same-repo events and runs with `always()` so results are uploaded on both success (clears resolved alerts) and failure (records findings).
