### PR TITLE
chore(typos): check hidden files consistently

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -371,10 +371,6 @@ jobs:
       - name: Check spelling
         if: github.event_name != 'pull_request'
         uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2
-        with:
-          files: |
-            .
-            .github/**
 
       - name: Check spelling (reviewdog)
         if: github.event_name == 'pull_request'
@@ -383,7 +379,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
           fail_level: error
-          typos_flags: --hidden .
+          typos_flags: .
 
   format-typst:
     name: Format Typst

--- a/.typos.toml
+++ b/.typos.toml
@@ -4,4 +4,6 @@ typ = "typ"
 [files]
 extend-exclude = [
   "*.bib",
+  ".git",
 ]
+ignore-hidden = false


### PR DESCRIPTION
The push run of `check-typos` listed `.` and `.github/**`, so hidden files at the repository root (`.yamllint.yaml`, `.cz.toml`, ...) were skipped, while the pull request run passed `--hidden` and checked everything.

Set `files.ignore-hidden = false` in `.typos.toml` (excluding `.git`) so local hooks and both CI paths cover the same files, and drop the now-redundant workarounds. Ran `typos .` over the full repository after the change; no new findings.
