### PR TITLE
ci: deny default token permissions in workflows lacking a top-level block

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -14,6 +14,8 @@ on:
           - minor
           - patch
 
+permissions: {}
+
 jobs:
 
   bump-version:

--- a/.github/workflows/generate-typst-pdf-diff.yaml
+++ b/.github/workflows/generate-typst-pdf-diff.yaml
@@ -32,6 +32,8 @@ concurrency:
 env:
   TYPST_TARGET_FILES: main.typ # Space-separated list of Typst entrypoint files
 
+permissions: {}
+
 jobs:
   generate-typst-pdf-diff:
     name: Generate Typst PDF Diff

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -14,6 +14,8 @@ on:
       - '.github/workflows/sync-labels.yaml'
       - '.github/labels/label-definition.yaml'
 
+permissions: {}
+
 jobs:
 
   sync-labels:


### PR DESCRIPTION
`bump-version.yaml`, `sync-labels.yaml`, and `generate-typst-pdf-diff.yaml` only granted permissions at the job level, leaving the workflow-level default in place. Set an empty `permissions: {}` block at the top level in each, matching `manage-pull-requests.yaml`.

`generate-typst-pdf-diff.yaml` is specific to this repository (it does not exist in the upstream `repository-template`), so it is included here alongside the two workflows carried over from upstream.
