### PR TITLE
ci: set a 10-minute timeout on every job

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -21,6 +21,7 @@ jobs:
   bump-version:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,7 @@ jobs:
   determine-changes:
     name: Determine changed files
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       github_actions: ${{ steps.changed-files.outputs.github_actions_any_changed }}
       github_actions_ci: ${{ steps.changed-files.outputs.github_actions_ci_any_changed }}
@@ -73,6 +74,7 @@ jobs:
     needs: determine-changes
     if: ${{ needs.determine-changes.outputs.github_actions == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -125,6 +127,7 @@ jobs:
       ${{ needs.determine-changes.outputs.renovate_config == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
 
@@ -151,6 +154,7 @@ jobs:
       ${{ needs.determine-changes.outputs.md == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -198,6 +202,7 @@ jobs:
       ${{ needs.determine-changes.outputs.json5 == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
 
@@ -236,6 +241,7 @@ jobs:
       ${{ needs.determine-changes.outputs.toml == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -311,6 +317,7 @@ jobs:
       ${{ needs.determine-changes.outputs.yaml == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -343,6 +350,7 @@ jobs:
   check-prek:
     name: Check prek
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout the main repository
@@ -359,6 +367,7 @@ jobs:
   check-typos:
     name: Check typos
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       checks: write
@@ -390,6 +399,7 @@ jobs:
       ${{ needs.determine-changes.outputs.typst == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -430,6 +440,7 @@ jobs:
       ${{ needs.determine-changes.outputs.typst == 'true' ||
       needs.determine-changes.outputs.github_actions_ci == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     strategy:
       matrix:
@@ -461,6 +472,7 @@ jobs:
   lint-commit-messages:
     name: Lint commit messages
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout the main repository

--- a/.github/workflows/generate-typst-pdf-diff.yaml
+++ b/.github/workflows/generate-typst-pdf-diff.yaml
@@ -38,6 +38,7 @@ jobs:
   generate-typst-pdf-diff:
     name: Generate Typst PDF Diff
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/manage-pull-requests.yaml
+++ b/.github/workflows/manage-pull-requests.yaml
@@ -15,6 +15,7 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
@@ -28,6 +29,7 @@ jobs:
     name: Lint PR title
     if: github.event.action != 'edited' || github.event.changes.title != null
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Set up Commitizen

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -21,6 +21,7 @@ jobs:
   sync-labels:
     name: Sync Labels
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
Jobs without `timeout-minutes` fall back to the 6-hour default, so a hung runner occupies its slot for hours.

Add a uniform `timeout-minutes: 10` to every job across the workflows. All jobs are short lint or automation tasks, so 10 minutes leaves ample headroom against transient slowness while capping hangs.
